### PR TITLE
Ensure that script exits non-zero when a command fails

### DIFF
--- a/package-build.sh
+++ b/package-build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 cd ses-cor-debian-base
 
 set -Eeuo pipefail

--- a/package-build.sh
+++ b/package-build.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 cd ses-cor-debian-base
 
-set -Eeuo pipefail
+set -Eeu
 
 ARTIFACTS=/opt/bamboo5.9/artifacts
 INTEGRATION_SHARED_DIR=${ARTIFACTS}/plan-569835545/shared

--- a/package-build.sh
+++ b/package-build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 cd ses-cor-debian-base
 
+set -Eeuo pipefail
+
 ARTIFACTS=/opt/bamboo5.9/artifacts
 INTEGRATION_SHARED_DIR=${ARTIFACTS}/plan-569835545/shared
 LATEST_BUILD_DIR=`ls -t ${INTEGRATION_SHARED_DIR}/|head -1`


### PR DESCRIPTION
This will prevent the situation where the build passes even when a command fails. See https://bamboo.pih-emr.org/browse/PERU-CEDP-14/log for an example.